### PR TITLE
fix: SFTP/FTP bugs, complete interactive mode & code quality (v1.6.2 prep)

### DIFF
--- a/src/advanced_download.rs
+++ b/src/advanced_download.rs
@@ -388,7 +388,7 @@ impl AdvancedDownloader {
             self.download_whole(&file, existing_size.unwrap_or(0), progress.clone())?;
             if let Some(ref bar) = progress {
                 bar.lock()
-                    .unwrap()
+                    .expect("Progress bar mutex was poisoned")
                     .finish_with_message("Download completed");
             }
             if !self.quiet_mode {
@@ -414,7 +414,7 @@ impl AdvancedDownloader {
 
         if let Some(ref bar) = progress {
             bar.lock()
-                .unwrap()
+                .expect("Progress bar mutex was poisoned")
                 .finish_with_message("Download completed");
         }
 
@@ -523,7 +523,7 @@ impl AdvancedDownloader {
             fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
                 let n = self.inner.write(buf)?;
                 if let Some(ref bar) = self.progress {
-                    let guard = bar.lock().unwrap();
+                    let guard = bar.lock().expect("Progress bar mutex was poisoned");
                     guard.inc(n as u64);
                     if let Some(cb) = self.callback {
                         let pos = guard.position();
@@ -624,7 +624,7 @@ impl AdvancedDownloader {
 
                                 // Print progress periodically (every 200ms) for pipe-friendly output
                                 {
-                                    let mut last_time = last_print_time.lock().unwrap();
+                                    let mut last_time = last_print_time.lock().expect("Timer mutex was poisoned");
                                     if last_time.elapsed() >= Duration::from_millis(200) {
                                         let percent = (new_downloaded as f64 / total_bytes as f64
                                             * 100.0)
@@ -639,7 +639,7 @@ impl AdvancedDownloader {
                                 }
 
                                 if let Some(ref bar) = progress {
-                                    let guard = bar.lock().unwrap();
+                                    let guard = bar.lock().expect("Progress bar mutex was poisoned");
                                     guard.inc(n as u64);
                                     if let Some(ref cb) = progress_callback {
                                         let pos = guard.position();

--- a/src/ftp/client.rs
+++ b/src/ftp/client.rs
@@ -101,7 +101,12 @@ impl FtpDownloader {
             FtpStream::connect((host, port))?
         };
 
-        let username = url.username();
+        // url.username() returns "" (empty string) when the URL has no user — fall back to "anonymous"
+        let username = if url.username().is_empty() {
+            "anonymous"
+        } else {
+            url.username()
+        };
         let password = url.password().unwrap_or("anonymous");
 
         print(&format!("Logging in as {}...", username), self.quiet_mode);

--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -1,39 +1,410 @@
+use kget::advanced_download::AdvancedDownloader;
+use kget::config::Config;
+use kget::download::download as http_download;
+use kget::ftp::FtpDownloader;
+use kget::optimization::Optimizer;
+use kget::sftp::SftpDownloader;
+use kget::utils;
+use kget::DownloadOptions;
 use rustyline::DefaultEditor;
 use rustyline::error::ReadlineError;
+use std::error::Error;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ASCII Banner
+// ─────────────────────────────────────────────────────────────────────────────
+
+const BANNER: &str = r#"
+  ██╗  ██╗ ██████╗ ███████╗████████╗
+  ██║ ██╔╝██╔════╝ ██╔════╝╚══██╔══╝
+  █████╔╝ ██║  ███╗█████╗     ██║
+  ██╔═██╗ ██║   ██║██╔══╝     ██║
+  ██║  ██╗╚██████╔╝███████╗   ██║
+  ╚═╝  ╚═╝ ╚═════╝ ╚══════╝   ╚═╝
+"#;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Parsed download arguments from the REPL line
+// ─────────────────────────────────────────────────────────────────────────────
+
+struct DownloadArgs {
+    url: String,
+    output: Option<String>,
+    quiet: bool,
+    advanced: bool,
+    ftp: bool,
+    sftp: bool,
+    torrent: bool,
+    sha256: Option<String>,
+}
+
+/// Parse flags and URL from the tokens after the `download` command.
+///
+/// Accepted flags:
+/// ```text
+/// -a / --advanced / --turbo     parallel multi-connection download
+/// -o / --output <path>          destination file or directory
+/// -q / --quiet                  suppress progress output
+/// --sha256 <hash>               verify file hash after download
+/// --ftp                         force FTP protocol
+/// --sftp                        force SFTP protocol
+/// --torrent                     force torrent/magnet handling
+/// ```
+fn parse_download_args(parts: &[&str]) -> Result<DownloadArgs, String> {
+    let mut args = DownloadArgs {
+        url: String::new(),
+        output: None,
+        quiet: false,
+        advanced: false,
+        ftp: false,
+        sftp: false,
+        torrent: false,
+        sha256: None,
+    };
+
+    let mut i = 0;
+    while i < parts.len() {
+        match parts[i] {
+            "-a" | "--advanced" | "--turbo" => args.advanced = true,
+            "-q" | "--quiet" => args.quiet = true,
+            "--ftp" => args.ftp = true,
+            "--sftp" => args.sftp = true,
+            "--torrent" => args.torrent = true,
+            "-o" | "--output" => {
+                i += 1;
+                if i >= parts.len() {
+                    return Err(format!("'{}' requires a path argument", parts[i - 1]));
+                }
+                args.output = Some(parts[i].to_string());
+            }
+            "--sha256" => {
+                i += 1;
+                if i >= parts.len() {
+                    return Err("'--sha256' requires a hash argument".to_string());
+                }
+                args.sha256 = Some(parts[i].to_string());
+            }
+            token if !token.starts_with('-') => {
+                if !args.url.is_empty() {
+                    return Err(format!(
+                        "Unexpected extra argument '{}'. Only one URL is supported.",
+                        token
+                    ));
+                }
+                args.url = token.to_string();
+            }
+            unknown => return Err(format!("Unknown flag: '{}'. Run 'help' for usage.", unknown)),
+        }
+        i += 1;
+    }
+
+    if args.url.is_empty() {
+        return Err("No URL provided.\n  Usage: download [flags] <url>".to_string());
+    }
+
+    Ok(args)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Download dispatcher
+// ─────────────────────────────────────────────────────────────────────────────
+
+fn run_download(args: DownloadArgs, config: &Config) -> Result<(), Box<dyn Error + Send + Sync>> {
+    let optimizer = Optimizer::from_config(config.optimization.clone());
+
+    // Auto-detect magnet links as torrent downloads
+    if args.torrent || args.url.starts_with("magnet:?") {
+        let output_dir = args
+            .output
+            .unwrap_or_else(|| "torrent_output".to_string());
+        return kget::torrent::download_magnet(
+            &args.url,
+            &output_dir,
+            args.quiet,
+            config.proxy.clone(),
+            optimizer,
+            kget::torrent::TorrentCallbacks::default(),
+        );
+    }
+
+    if args.ftp {
+        let output = utils::resolve_output_path(args.output, &args.url, "ftp_output");
+        let dl = FtpDownloader::new(
+            args.url,
+            output,
+            args.quiet,
+            config.proxy.clone(),
+            optimizer,
+        );
+        return dl.download();
+    }
+
+    if args.sftp {
+        let output = utils::resolve_output_path(args.output, &args.url, "sftp_output");
+        let dl = SftpDownloader::new(
+            args.url,
+            output,
+            args.quiet,
+            config.proxy.clone(),
+            optimizer,
+        );
+        return dl.download();
+    }
+
+    if args.advanced {
+        let output = utils::resolve_output_path(args.output, &args.url, "download");
+        let mut dl = AdvancedDownloader::new(
+            args.url,
+            output,
+            args.quiet,
+            config.proxy.clone(),
+            optimizer,
+        );
+        if let Some(hash) = args.sha256 {
+            dl.set_expected_sha256(hash);
+        }
+        return dl.download();
+    }
+
+    // Default: simple HTTP/HTTPS
+    let options = DownloadOptions {
+        quiet_mode: args.quiet,
+        output_path: args.output,
+        verify_iso: args.sha256.is_some(),
+        expected_sha256: args.sha256,
+    };
+    http_download(&args.url, config.proxy.clone(), optimizer, options, None)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Config sub-commands
+// ─────────────────────────────────────────────────────────────────────────────
+
+fn cmd_config(parts: &[&str], config: &mut Config) -> Result<(), Box<dyn Error + Send + Sync>> {
+    let subcmd = parts.first().copied().unwrap_or("show");
+    match subcmd {
+        "show" => {
+            println!("Current configuration:");
+            println!(
+                "  connections   {}",
+                config.optimization.max_connections
+            );
+            println!(
+                "  speed-limit   {}",
+                match config.optimization.speed_limit {
+                    Some(s) => format!("{} B/s", s),
+                    None => "unlimited".to_string(),
+                }
+            );
+            println!("  compression   {}", config.optimization.compression);
+            println!("  cache         {}", config.optimization.cache_enabled);
+            println!(
+                "  proxy         {}",
+                if config.proxy.enabled {
+                    config
+                        .proxy
+                        .url
+                        .as_deref()
+                        .unwrap_or("(enabled but no URL set)")
+                        .to_string()
+                } else {
+                    "disabled".to_string()
+                }
+            );
+        }
+        "set" => {
+            if parts.len() < 3 {
+                println!("Usage: config set <key> <value>");
+                println!("  keys: connections, speed-limit, compression, cache");
+                return Ok(());
+            }
+            let key = parts[1];
+            let value = parts[2];
+            match key {
+                "connections" => {
+                    let n: usize = value
+                        .parse()
+                        .map_err(|_| format!("'{}' is not a valid number", value))?;
+                    config.optimization.max_connections = n.clamp(1, 32);
+                    config.save()?;
+                    println!("Max connections set to {}", config.optimization.max_connections);
+                }
+                "speed-limit" => {
+                    if value == "0" || value == "unlimited" {
+                        config.optimization.speed_limit = None;
+                        println!("Speed limit removed (unlimited)");
+                    } else {
+                        let n: u64 = value
+                            .parse()
+                            .map_err(|_| format!("'{}' is not a valid number of bytes", value))?;
+                        config.optimization.speed_limit = Some(n);
+                        println!("Speed limit set to {} B/s", n);
+                    }
+                    config.save()?;
+                }
+                "compression" => {
+                    let v: bool = value
+                        .parse()
+                        .map_err(|_| format!("'{}' is not 'true' or 'false'", value))?;
+                    config.optimization.compression = v;
+                    config.save()?;
+                    println!("Compression set to {}", v);
+                }
+                "cache" => {
+                    let v: bool = value
+                        .parse()
+                        .map_err(|_| format!("'{}' is not 'true' or 'false'", value))?;
+                    config.optimization.cache_enabled = v;
+                    config.save()?;
+                    println!("Cache set to {}", v);
+                }
+                unknown => {
+                    println!(
+                        "Unknown config key: '{}'\n  Available keys: connections, speed-limit, compression, cache",
+                        unknown
+                    );
+                }
+            }
+        }
+        _ => println!("Usage: config [show | set <key> <value>]"),
+    }
+    Ok(())
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Help text
+// ─────────────────────────────────────────────────────────────────────────────
+
+fn print_help() {
+    println!(
+        r#"
+Commands
+────────
+  download [flags] <url>     Download a file
+
+    Flags:
+      -a, --advanced         Turbo mode: parallel connections, resumable
+          --turbo            Alias for --advanced
+      -o, --output <path>    Save to this file or directory
+      -q, --quiet            No progress output
+          --sha256 <hash>    Verify SHA-256 after download
+          --ftp              Use FTP protocol  (ftp://[user:pass@]host/path)
+          --sftp             Use SFTP protocol (sftp://[user[:pass]@]host/path)
+          --torrent          Force torrent/magnet handling
+
+  config                     Show current configuration
+  config show                Show current configuration
+  config set <key> <value>   Update a setting
+    keys:
+      connections  <1-32>           Parallel HTTP connections
+      speed-limit  <bytes/s | 0>   Bandwidth cap (0 = unlimited)
+      compression  <true|false>     Enable compression cache
+      cache        <true|false>     Enable local download cache
+
+  clear                      Clear the terminal screen
+  version                    Show KGet version
+  help                       Show this help
+  exit / quit                Exit interactive mode
+
+Examples
+────────
+  download https://example.com/file.zip
+  download -a -o ~/Downloads/ubuntu.iso https://releases.ubuntu.com/...
+  download --sha256 abc123 https://example.com/checksummed.tar.gz
+  download --ftp ftp://ftp.gnu.org/gnu/emacs/emacs-28.2.tar.gz
+  download --sftp sftp://user@server.com/backups/db.sql.gz
+  download magnet:?xt=urn:btih:...
+  config set connections 8
+  config set speed-limit 1048576
+  config set speed-limit 0
+"#
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Entry point
+// ─────────────────────────────────────────────────────────────────────────────
 
 pub fn interactive_mode() {
-    let mut rl = DefaultEditor::new().unwrap();
-    println!("KGet Interactive Mode. Type 'help' for commands, 'exit' to quit.");
+    println!("{}", BANNER);
+    println!("  Fast, Multi-Protocol Download Manager");
+    println!("  v{}  —  Interactive Mode", env!("CARGO_PKG_VERSION"));
+    println!("  Type 'help' for commands, 'exit' to quit.\n");
+
+    let mut config = Config::load().unwrap_or_else(|e| {
+        eprintln!("Warning: could not load config ({}). Using defaults.", e);
+        Config::default()
+    });
+
+    let mut rl = match DefaultEditor::new() {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("Failed to initialise line editor: {}", e);
+            return;
+        }
+    };
 
     loop {
         let readline = rl.readline("kget> ");
         match readline {
             Ok(line) => {
                 let input = line.trim();
+                if input.is_empty() {
+                    continue;
+                }
                 let _ = rl.add_history_entry(input);
 
-                match input {
+                let parts: Vec<&str> = input.split_whitespace().collect();
+                let cmd = parts[0];
+
+                match cmd {
                     "exit" | "quit" => {
-                        println!("Bye!");
+                        println!("Goodbye!");
                         break;
                     }
-                    "help" => {
-                        println!("Available commands: help, exit, download <url> [output]");
+                    "help" | "?" => print_help(),
+                    "version" => println!("KGet v{}", env!("CARGO_PKG_VERSION")),
+                    "clear" => {
+                        // ANSI escape: clear screen, move cursor to top-left
+                        print!("\x1B[2J\x1B[1;1H");
+                        let _ = {
+                            use std::io::Write;
+                            std::io::stdout().flush()
+                        };
                     }
-                    cmd if cmd.starts_with("download ") => {
-                        // Parse and call your download logic here
-                        println!("Would download: {}", &cmd["download ".len()..]);
+                    "config" => {
+                        let sub = &parts[1..];
+                        if let Err(e) = cmd_config(sub, &mut config) {
+                            eprintln!("Config error: {}", e);
+                        }
                     }
-                    "" => {} // Ignore empty
-                    _ => println!("Unknown command: '{}'", input),
+                    "download" | "get" | "dl" => {
+                        let dl_parts = &parts[1..];
+                        if dl_parts.is_empty() {
+                            eprintln!("Error: No URL provided.\n  Usage: download [flags] <url>");
+                            continue;
+                        }
+                        match parse_download_args(dl_parts) {
+                            Ok(args) => {
+                                if let Err(e) = run_download(args, &config) {
+                                    eprintln!("Download failed: {}", e);
+                                }
+                            }
+                            Err(e) => eprintln!("Error: {}", e),
+                        }
+                    }
+                    _ => eprintln!(
+                        "Unknown command: '{}'. Type 'help' to see available commands.",
+                        cmd
+                    ),
                 }
             }
             Err(ReadlineError::Interrupted) | Err(ReadlineError::Eof) => {
-                println!("Bye!");
+                println!("Goodbye!");
                 break;
             }
             Err(err) => {
-                println!("Error: {:?}", err);
+                eprintln!("Readline error: {:?}", err);
                 break;
             }
         }

--- a/src/optimization.rs
+++ b/src/optimization.rs
@@ -95,7 +95,6 @@ impl Optimizer {
     /// - Levels 7-9: Brotli (high compression)
     ///
     /// Returns the original data unchanged if compression is disabled.
-    #[allow(dead_code)]
     pub fn compress(&self, data: &[u8]) -> Result<Vec<u8>, Box<dyn Error>> {
         if !self.config.compression {
             return Ok(data.to_vec());
@@ -155,7 +154,6 @@ impl Optimizer {
     /// - `Ok(Some(data))` if the file exists in cache
     /// - `Ok(None)` if caching is disabled or file doesn't exist
     /// - `Err` on I/O errors
-    #[allow(dead_code)]
     pub fn get_cached_file(&self, url: &str) -> Result<Option<Vec<u8>>, Box<dyn Error>> {
         if !self.config.cache_enabled {
             return Ok(None);
@@ -172,10 +170,9 @@ impl Optimizer {
         Ok(None)
     }
 
-    /// Store a file in the cache
+    /// Store a file in the cache.
     ///
-    /// Does nothing if caching is disabled
-    #[allow(dead_code)]
+    /// Does nothing if caching is disabled.
     pub fn cache_file(&self, url: &str, data: &[u8]) -> Result<(), Box<dyn Error>> {
         if !self.config.cache_enabled {
             return Ok(());
@@ -189,10 +186,7 @@ impl Optimizer {
         Ok(())
     }
 
-    /// Generate the cache file path based on the URL
-    ///
-    /// Uses a simple hash to generate a unique filename
-    #[allow(dead_code)]
+    /// Generate the cache file path for a URL using a simple hash.
     fn get_cache_path(&self, url: &str) -> Result<PathBuf, Box<dyn Error>> {
         let mut cache_dir = PathBuf::from(if self.config.cache_dir.is_empty() {
             "~/.cache/kget".to_string()

--- a/src/sftp/mod.rs
+++ b/src/sftp/mod.rs
@@ -7,14 +7,30 @@
 //! SFTP provides encrypted file transfer, unlike plain FTP.
 //! Authentication is handled via SSH (password or key-based).
 //!
+//! # Authentication Order
+//!
+//! 1. Password embedded in URL (`sftp://user:pass@host/path`)
+//! 2. SSH agent (if running)
+//! 3. Default key files (`~/.ssh/id_ed25519`, `~/.ssh/id_rsa`, `~/.ssh/id_ecdsa`)
+//!
 //! # Example
 //!
 //! ```rust,no_run
 //! use kget::sftp::SftpDownloader;
 //! use kget::{ProxyConfig, Optimizer};
 //!
+//! // Password authentication
 //! let downloader = SftpDownloader::new(
-//!     "sftp://user@server.com:22/path/to/file".to_string(),
+//!     "sftp://user:pass@server.com:22/path/to/file".to_string(),
+//!     "local_file.txt".to_string(),
+//!     false,
+//!     ProxyConfig::default(),
+//!     Optimizer::new(),
+//! );
+//!
+//! // Key-based (uses SSH agent or ~/.ssh/id_* automatically)
+//! let downloader = SftpDownloader::new(
+//!     "sftp://user@server.com/path/to/file".to_string(),
 //!     "local_file.txt".to_string(),
 //!     false,
 //!     ProxyConfig::default(),
@@ -26,18 +42,19 @@
 
 use crate::config::ProxyConfig;
 use crate::optimization::Optimizer;
+use crate::progress::create_progress_bar;
 use std::error::Error;
-use std::io::Read;
+use std::io::{Read, Write};
+use url::Url;
 
 /// SFTP file downloader using SSH.
 ///
 /// Downloads files securely over SSH File Transfer Protocol.
 ///
-/// # Note
-///
-/// Currently requires the SSH session to be established manually.
-/// For key-based authentication, configure `SftpConfig.key_path` in
-/// the application config.
+/// Authentication tries, in order:
+/// 1. Password from the URL (`sftp://user:pass@host/path`)
+/// 2. Running SSH agent
+/// 3. Default key files in `~/.ssh/`
 pub struct SftpDownloader {
     url: String,
     output: String,
@@ -53,10 +70,10 @@ impl SftpDownloader {
     ///
     /// # Arguments
     ///
-    /// * `url` - SFTP URL (e.g., "sftp://user@host/path")
+    /// * `url` - SFTP URL (e.g., `sftp://user:pass@host/path` or `sftp://user@host/path`)
     /// * `output` - Local path to save the file
     /// * `quiet` - Suppress console output
-    /// * `proxy` - Proxy configuration
+    /// * `proxy` - Proxy configuration (not used for SFTP; SSH tunneling must be configured at OS level)
     /// * `optimizer` - Optimizer instance
     pub fn new(
         url: String,
@@ -74,22 +91,168 @@ impl SftpDownloader {
         }
     }
 
+    /// Download the file via SFTP.
     pub fn download(&self) -> Result<(), Box<dyn Error + Send + Sync>> {
-        let tcp = std::net::TcpStream::connect(&self.url)?;
-        let mut sess = ssh2::Session::new()?;
-        sess.set_tcp_stream(tcp);
-        sess.handshake()?;
+        let parsed = Url::parse(&self.url)
+            .map_err(|e| format!("Invalid SFTP URL '{}': {}", self.url, e))?;
 
-        let sftp = sess.sftp()?;
-        let mut remote_file = sftp.open(std::path::Path::new(&self.url))?;
-        let mut contents = Vec::new();
-        remote_file.read_to_end(&mut contents)?;
+        if parsed.scheme() != "sftp" {
+            return Err(format!(
+                "Expected sftp:// URL, got scheme '{}'",
+                parsed.scheme()
+            )
+            .into());
+        }
 
-        std::fs::write(&self.output, contents)?;
+        let host = parsed
+            .host_str()
+            .ok_or("SFTP URL is missing a host (expected sftp://user@host/path)")?;
+        let port = parsed.port().unwrap_or(22);
+        let remote_path = parsed.path();
+
+        if remote_path.is_empty() || remote_path == "/" {
+            return Err("SFTP URL must include a file path (e.g., sftp://user@host/path/to/file)"
+                .into());
+        }
+
+        let username = if parsed.username().is_empty() {
+            std::env::var("USER")
+                .or_else(|_| std::env::var("USERNAME"))
+                .unwrap_or_else(|_| "anonymous".to_string())
+        } else {
+            parsed.username().to_string()
+        };
 
         if !self.quiet {
-            println!("Downloaded {} to {}", self.url, self.output);
+            println!("Connecting to {}:{} ...", host, port);
         }
+
+        let tcp = std::net::TcpStream::connect((host, port))
+            .map_err(|e| format!("Cannot connect to {}:{} — {}", host, port, e))?;
+
+        let mut sess = ssh2::Session::new()
+            .map_err(|e| format!("SSH session init failed: {}", e))?;
+        sess.set_tcp_stream(tcp);
+        sess.handshake()
+            .map_err(|e| format!("SSH handshake with {}:{} failed: {}", host, port, e))?;
+
+        // Authenticate: password from URL → SSH agent → default key files
+        if let Some(password) = parsed.password() {
+            sess.userauth_password(&username, password)
+                .map_err(|e| format!("Password authentication for '{}' failed: {}", username, e))?;
+        } else {
+            self.try_key_auth(&sess, &username)?;
+        }
+
+        if !sess.authenticated() {
+            return Err(format!(
+                "SFTP authentication failed for user '{}' on {}:{}. \
+                 Provide password in URL (sftp://user:pass@host/path) or configure SSH keys/agent.",
+                username, host, port
+            )
+            .into());
+        }
+
+        if !self.quiet {
+            println!("Authenticated as '{}'. Opening SFTP channel...", username);
+        }
+
+        let sftp = sess
+            .sftp()
+            .map_err(|e| format!("Failed to open SFTP channel: {}", e))?;
+
+        let remote = std::path::Path::new(remote_path);
+
+        // Get file size for the progress bar (best-effort; fall back to spinner)
+        let file_size = sftp.stat(remote).ok().and_then(|s| s.size);
+
+        if !self.quiet {
+            match file_size {
+                Some(sz) => println!("Remote file size: {} bytes", sz),
+                None => println!("Remote file size unknown"),
+            }
+        }
+
+        let progress = create_progress_bar(
+            self.quiet,
+            remote_path.to_string(),
+            file_size,
+            false,
+        );
+
+        let mut remote_file = sftp
+            .open(remote)
+            .map_err(|e| format!("Cannot open remote file '{}': {}", remote_path, e))?;
+
+        let mut dest = std::fs::File::create(&self.output)
+            .map_err(|e| format!("Cannot create local file '{}': {}", self.output, e))?;
+
+        let mut buffer = [0u8; 32768];
+        loop {
+            let n = remote_file
+                .read(&mut buffer)
+                .map_err(|e| format!("SFTP read error: {}", e))?;
+            if n == 0 {
+                break;
+            }
+            dest.write_all(&buffer[..n])
+                .map_err(|e| format!("Write error to '{}': {}", self.output, e))?;
+            progress.inc(n as u64);
+        }
+
+        progress.finish_with_message("Download complete");
+
+        if !self.quiet {
+            println!("Saved to '{}'", self.output);
+        }
+
+        Ok(())
+    }
+
+    /// Try SSH agent first, then fall back to well-known key files.
+    fn try_key_auth(
+        &self,
+        sess: &ssh2::Session,
+        username: &str,
+    ) -> Result<(), Box<dyn Error + Send + Sync>> {
+        // 1. SSH agent
+        if let Ok(mut agent) = sess.agent() {
+            if agent.connect().is_ok() && agent.list_identities().is_ok() {
+                if let Ok(identities) = agent.identities() {
+                    for identity in &identities {
+                        if agent.userauth(username, identity).is_ok() && sess.authenticated() {
+                            return Ok(());
+                        }
+                    }
+                }
+            }
+        }
+
+        // 2. Default key files
+        let home = match dirs::home_dir() {
+            Some(h) => h,
+            None => return Ok(()), // Let caller handle the unauthenticated state
+        };
+
+        let key_candidates = [
+            home.join(".ssh/id_ed25519"),
+            home.join(".ssh/id_rsa"),
+            home.join(".ssh/id_ecdsa"),
+        ];
+
+        for key_path in &key_candidates {
+            if key_path.exists() {
+                if sess
+                    .userauth_pubkey_file(username, None, key_path, None)
+                    .is_ok()
+                    && sess.authenticated()
+                {
+                    return Ok(());
+                }
+            }
+        }
+
+        // Return Ok regardless — caller checks sess.authenticated()
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary

- **Fix SFTP** — protocol was completely non-functional; full rewrite with proper URL parsing, multi-method SSH authentication, and streaming with progress bar
- **Fix FTP** — anonymous login failed when URL contained no username (`url.username()` returns `""`, not `None`)
- **Interactive mode** — previously a stub that only printed `"Would download: ..."` ; now a full REPL with ASCII art banner and real download support for all protocols
- **Code quality** — replace `unwrap()` on Mutex locks with `expect()` + message; remove unnecessary `#[allow(dead_code)]` from public `Optimizer` API

## What changed

### `src/sftp/mod.rs` (rewrite)
The original code did `TcpStream::connect(&self.url)` where `self.url` is the full `sftp://...` string — this always panicked. Also opened the remote file with the full URL string as the path.

**Now:**
1. Parse URL → extract `host`, `port`, `username`, `remote_path`
2. Authenticate in priority order: **password in URL → SSH agent → `~/.ssh/id_ed25519` / `id_rsa` / `id_ecdsa`**
3. Stream download with 32 KB buffer + `indicatif` progress bar
4. Clear error messages at each failure point

### `src/ftp/client.rs`
`url.username()` from the `url` crate returns `""` (empty `&str`), not `None`, when the URL has no user segment. The old code passed the empty string to `ftp.login()`, causing anonymous FTP servers to reject the connection. Now falls back to `"anonymous"`.

### `src/interactive.rs` (rewrite)
Previously the `download` command in the REPL only printed `"Would download: ..."` with no actual download logic.

**Now:**
- Unicode block-font ASCII art banner on entry
- `rustyline` REPL with command history
- `download [flags] <url>` — dispatches to the right downloader:
  - plain HTTP/HTTPS (default)
  - `-a` / `--advanced` / `--turbo` → `AdvancedDownloader` (parallel, resumable)
  - `--ftp` → `FtpDownloader`
  - `--sftp` → `SftpDownloader`
  - `--torrent` or `magnet:?` prefix → torrent engine (auto-detected)
  - `-o <path>`, `-q`, `--sha256 <hash>` flags
- `config [show | set <key> <value>]` — reads and saves settings (connections, speed-limit, compression, cache)
- `clear`, `version`, `help` / `?`, `exit` / `quit`
- Command aliases: `get`, `dl` → `download`

### `src/advanced_download.rs`
4× `.unwrap()` on `Mutex::lock()` replaced with `.expect("Progress bar mutex was poisoned")` / `.expect("Timer mutex was poisoned")`.

### `src/optimization.rs`
Removed `#[allow(dead_code)]` from public methods `compress`, `get_cached_file`, `cache_file` and private `get_cache_path` — these are valid public API, the attributes were suppressing legitimate lint signal.

## Test plan

- [ ] `kget --sftp sftp://user:pass@host/path/to/file` — verify connection and download complete
- [ ] `kget --sftp sftp://user@host/path` — verify SSH agent / key auth fallback
- [ ] `kget --ftp ftp://ftp.gnu.org/gnu/emacs/emacs-28.2.tar.gz` — verify anonymous login works
- [ ] `kget --interactive` — verify banner appears, `download https://...` actually downloads, `config set connections 8` persists, `help` shows all commands
- [ ] `cargo test` — all existing tests pass
- [ ] `cargo check` — no warnings ✅ (verified during implementation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)