### PR TITLE
docs: v1.6.2 documentation update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0.html),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.2] - 2026-04-28
+
+### Fixed
+- **SFTP downloads were completely non-functional.** The previous implementation passed the full `sftp://…` URL string directly to `TcpStream::connect` and used it as the remote file path, causing an immediate connection error on every SFTP call. The module is now fully rewritten:
+  - URL is parsed to extract `host`, `port`, `username`, and `remote_path` correctly.
+  - Authentication tries in priority order: password embedded in the URL → running SSH agent → default key files (`~/.ssh/id_ed25519`, `~/.ssh/id_rsa`, `~/.ssh/id_ecdsa`).
+  - File is streamed in 32 KB chunks with a real-time progress bar.
+  - Clear, actionable error messages at every failure point.
+- **FTP anonymous login failed when the URL contained no username.** `url.username()` from the `url` crate returns an empty string `""` (not `None`) when the URL has no user segment. Passing `""` to `ftp.login()` caused anonymous FTP servers to reject the connection. The downloader now falls back to `"anonymous"` in that case.
+
+### Added
+- **Interactive mode is now fully implemented.** Previously `kget --interactive` opened a REPL that only printed `"Would download: …"` without performing any actual download. The mode is now feature-complete:
+  - Unicode block-font ASCII art banner on entry.
+  - `rustyline` line editor with persistent command history.
+  - `download [flags] <url>` — dispatches to the correct downloader based on flags:
+    - Default: simple HTTP/HTTPS with retry and progress bar.
+    - `-a` / `--advanced` / `--turbo`: `AdvancedDownloader` (parallel byte-range, resumable).
+    - `--ftp`: FTP downloader with anonymous fallback.
+    - `--sftp`: SFTP downloader with multi-method SSH auth.
+    - `--torrent` or auto-detected `magnet:?` prefix: native torrent engine.
+    - `-o <path>`, `-q` (quiet), `--sha256 <hash>` flags supported.
+  - `config [show | set <key> <value>]`: reads and persists settings (`connections`, `speed-limit`, `compression`, `cache`).
+  - `clear`, `version`, `help` / `?` commands; `get`, `dl` as aliases for `download`.
+  - Errors are printed and the REPL continues — a failed download never crashes the session.
+
+### Changed
+- **Mutex lock error handling in `AdvancedDownloader`:** all `.unwrap()` calls on `Mutex::lock()` replaced with `.expect("…")` and descriptive messages, making panics easier to diagnose if a lock is ever poisoned.
+- **`Optimizer` public API cleanup:** removed `#[allow(dead_code)]` from the public methods `compress`, `get_cached_file`, and `cache_file` — these are valid library API surface and the suppression was masking legitimate lint signal.
+
 ## [1.6.1] - 2026-04-27
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "Kget"
-version = "1.6.1"
+version = "1.6.2"
 edition = "2024"
 description = "A powerful and versatile download manager and library"
 authors = ["Davi Moreira Fuzatto <davimoreiraf@gmail.com>"]

--- a/LIB.md
+++ b/LIB.md
@@ -11,7 +11,7 @@ resume support, proxy support, and SHA256 verification.
 
 ```toml
 [dependencies]
-Kget = "1.6.1"
+Kget = "1.6.2"
 ```
 
 Optional features:
@@ -142,5 +142,56 @@ falls back to the platform's default external magnet handler.
 - Files are streamed to disk instead of loaded fully into memory.
 - Output filenames are validated against path separators.
 - SHA256 helpers return errors on expected-hash mismatches.
+
+## FTP Download
+
+```rust,no_run
+use kget::ftp::FtpDownloader;
+use kget::{Optimizer, ProxyConfig};
+
+// Anonymous FTP (no credentials required)
+let dl = FtpDownloader::new(
+    "ftp://ftp.gnu.org/gnu/emacs/emacs-28.2.tar.gz".to_string(),
+    "emacs-28.2.tar.gz".to_string(),
+    false,
+    ProxyConfig::default(),
+    Optimizer::new(),
+);
+dl.download()?;
+# Ok::<(), Box<dyn std::error::Error + Send + Sync>>(())
+```
+
+## SFTP Download
+
+```rust,no_run
+use kget::sftp::SftpDownloader;
+use kget::{Optimizer, ProxyConfig};
+
+// Password embedded in the URL
+let dl = SftpDownloader::new(
+    "sftp://user:pass@server.example.com/path/to/file.tar.gz".to_string(),
+    "file.tar.gz".to_string(),
+    false,
+    ProxyConfig::default(),
+    Optimizer::new(),
+);
+dl.download()?;
+
+// Key-based authentication — uses SSH agent or ~/.ssh/id_ed25519, id_rsa, id_ecdsa automatically
+let dl = SftpDownloader::new(
+    "sftp://user@server.example.com/path/to/file.tar.gz".to_string(),
+    "file.tar.gz".to_string(),
+    false,
+    ProxyConfig::default(),
+    Optimizer::new(),
+);
+dl.download()?;
+# Ok::<(), Box<dyn std::error::Error + Send + Sync>>(())
+```
+
+Authentication priority:
+1. Password from URL (`sftp://user:pass@host/path`)
+2. Running SSH agent
+3. Default key files (`~/.ssh/id_ed25519`, `~/.ssh/id_rsa`, `~/.ssh/id_ecdsa`)
 
 See [examples/lib_usage.rs](examples/lib_usage.rs) for a larger cookbook.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <img width="1000" height="500" alt="KGet Banner" src="https://github.com/user-attachments/assets/d0888e3f-90a2-42d6-a9aa-b216dc36f1f4" />
 
-# KGet v1.6.1
+# KGet v1.6.2
 
 A fast, modern download manager written in Rust. Supports HTTP/HTTPS, FTP/SFTP, and **magnet links** with a built-in torrent client.
 
@@ -11,6 +11,7 @@ A fast, modern download manager written in Rust. Supports HTTP/HTTPS, FTP/SFTP, 
 - **Multi-protocol:** HTTP, HTTPS, FTP, SFTP, and Magnet links
 - **Native Torrent Client:** Downloads torrents directly — no external apps needed
 - **Turbo Mode:** Parallel connections for faster downloads
+- **Interactive REPL:** Full `kget --interactive` mode with history, all protocols, and live config editing
 - **GUI & CLI:** Use whichever you prefer
 - **Cross-platform:** macOS, Linux, Windows
 - **ISO Verification:** Optional SHA256 checksum for disk images
@@ -63,32 +64,59 @@ kget --gui
 # Basic download
 kget https://example.com/file.zip
 
-# Turbo mode (parallel connections)
+# Turbo mode (parallel connections, resumable)
 kget -a https://example.com/large.iso
 
 # Save to specific location
 kget -O ~/Downloads/myfile.zip https://example.com/file.zip
 
-# Torrent download
+# Torrent download (auto-detected)
 kget "magnet:?xt=urn:btih:HASH..."
 
-# FTP/SFTP
-kget ftp://user:pass@server/file.zip
-kget sftp://user@server/file.dat
+# FTP – anonymous (no credentials needed)
+kget --ftp ftp://ftp.gnu.org/gnu/emacs/emacs-28.2.tar.gz
+
+# FTP – authenticated
+kget --ftp ftp://user:pass@server/file.zip
+
+# SFTP – password in URL
+kget --sftp sftp://user:pass@server/path/to/file.dat
+
+# SFTP – key-based (SSH agent or ~/.ssh/id_*)
+kget --sftp sftp://user@server/path/to/file.dat
+```
+
+### Interactive Mode
+
+```bash
+kget --interactive
+```
+
+Launches a REPL with an ASCII art banner, command history, and full protocol support:
+
+```
+kget> download -a -o ~/Downloads/ubuntu.iso https://releases.ubuntu.com/...
+kget> download --sftp sftp://user@server/backups/db.sql.gz
+kget> download magnet:?xt=urn:btih:...
+kget> config set connections 8
+kget> config set speed-limit 1048576
+kget> help
 ```
 
 ### Options
 
 | Flag | Description |
 |------|-------------|
-| `-a, --advanced` | Turbo mode with parallel connections |
+| `-a, --advanced` | Turbo mode with parallel connections (resumable) |
 | `-O <path>` | Output file or directory |
 | `-q, --quiet` | Minimal output |
 | `-p <proxy>` | Use HTTP/SOCKS5 proxy |
 | `-l <bytes>` | Speed limit in bytes/sec |
 | `--sha256 <hash>` | Verify the completed file against an expected SHA256 hash |
+| `--ftp` | Use FTP protocol |
+| `--sftp` | Use SFTP protocol (password or key-based auth) |
 | `--gui` | Launch graphical interface |
-| `--interactive` | Interactive REPL mode |
+| `-i, --interactive` | Interactive REPL mode |
 
 ## Library Usage
 

--- a/translations/CHANGELOG.es.md
+++ b/translations/CHANGELOG.es.md
@@ -7,6 +7,35 @@ Todos los cambios notables en este proyecto serán documentados en este archivo.
 El formato está basado en [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 y este proyecto se adhiere al [Versionado Semántico](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.2] - 2026-04-28
+
+### Corregido
+- **Las descargas SFTP eran completamente no funcionales.** La implementación anterior pasaba la cadena completa `sftp://…` directamente a `TcpStream::connect` y la usaba como ruta remota, provocando un fallo inmediato en cada llamada SFTP. El módulo fue reescrito por completo:
+  - La URL se parsea correctamente para extraer `host`, `puerto`, `usuario` y `ruta remota`.
+  - Autenticación en orden de prioridad: contraseña en la URL → agente SSH activo → archivos de clave predeterminados (`~/.ssh/id_ed25519`, `~/.ssh/id_rsa`, `~/.ssh/id_ecdsa`).
+  - Archivo transmitido en chunks de 32 KB con barra de progreso en tiempo real.
+  - Mensajes de error claros y accionables en cada punto de fallo.
+- **El login anónimo FTP fallaba cuando la URL no contenía usuario.** `url.username()` de la crate `url` devuelve una cadena vacía `""` (no `None`) cuando la URL no tiene segmento de usuario. Pasar `""` a `ftp.login()` hacía que los servidores FTP anónimos rechazaran la conexión. El downloader ahora usa `"anonymous"` como fallback.
+
+### Añadido
+- **Modo interactivo completamente implementado.** Anteriormente `kget --interactive` abría un REPL que solo imprimía `"Would download: …"` sin realizar ninguna descarga. El modo ahora está completo:
+  - Banner de entrada con arte ASCII en fuente de bloques Unicode.
+  - Editor de línea `rustyline` con historial de comandos persistente.
+  - `download [flags] <url>` — activa el downloader correcto según los flags:
+    - Por defecto: HTTP/HTTPS simple con retry y barra de progreso.
+    - `-a` / `--advanced` / `--turbo`: `AdvancedDownloader` (paralelo con byte range, reanudable).
+    - `--ftp`: downloader FTP con fallback anónimo.
+    - `--sftp`: downloader SFTP con autenticación SSH multi-método.
+    - `--torrent` o prefijo `magnet:?` detectado automáticamente: motor de torrent nativo.
+    - Flags `-o <ruta>`, `-q` (silencioso), `--sha256 <hash>` soportados.
+  - `config [show | set <clave> <valor>]`: lee y persiste configuraciones (`connections`, `speed-limit`, `compression`, `cache`).
+  - Comandos `clear`, `version`, `help` / `?`; `get` y `dl` como alias de `download`.
+  - Los errores se imprimen y el REPL continúa — un error de descarga nunca cierra la sesión.
+
+### Cambiado
+- **Manejo de errores en locks Mutex en `AdvancedDownloader`:** todas las llamadas `.unwrap()` en `Mutex::lock()` reemplazadas por `.expect("…")` con mensajes descriptivos.
+- **Limpieza de la API pública de `Optimizer`:** eliminados atributos `#[allow(dead_code)]` de los métodos públicos `compress`, `get_cached_file` y `cache_file`.
+
 ## [1.6.1] - 2026-04-27
 
 ### Añadido

--- a/translations/CHANGELOG.pt-BR.md
+++ b/translations/CHANGELOG.pt-BR.md
@@ -7,6 +7,35 @@ Todas as mudanças notáveis neste projeto serão documentadas neste arquivo.
 O formato é baseado em [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 e este projeto adere ao [Versionamento Semântico](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.2] - 2026-04-28
+
+### Corrigido
+- **Downloads SFTP completamente não funcionais.** A implementação anterior passava a string `sftp://…` inteira para `TcpStream::connect` e a usava como caminho remoto, causando falha imediata em toda chamada SFTP. O módulo foi totalmente reescrito:
+  - A URL é parseada corretamente para extrair `host`, `porta`, `usuário` e `caminho remoto`.
+  - Autenticação em ordem de prioridade: senha na URL → SSH agent ativo → arquivos de chave padrão (`~/.ssh/id_ed25519`, `~/.ssh/id_rsa`, `~/.ssh/id_ecdsa`).
+  - Arquivo transmitido em chunks de 32 KB com barra de progresso em tempo real.
+  - Mensagens de erro claras e acionáveis em cada ponto de falha.
+- **Login anônimo FTP falhava quando a URL não continha usuário.** `url.username()` da crate `url` retorna string vazia `""` (não `None`) quando a URL não tem segmento de usuário. Passar `""` para `ftp.login()` fazia servidores FTP anônimos rejeitarem a conexão. O downloader agora usa `"anonymous"` como fallback.
+
+### Adicionado
+- **Modo interativo completamente implementado.** Anteriormente `kget --interactive` abria um REPL que apenas imprimia `"Would download: …"` sem realizar nenhum download. O modo agora está completo:
+  - Banner de entrada com arte ASCII em fonte de blocos Unicode.
+  - Editor de linha `rustyline` com histórico de comandos persistente.
+  - `download [flags] <url>` — aciona o downloader correto conforme os flags:
+    - Padrão: HTTP/HTTPS simples com retry e barra de progresso.
+    - `-a` / `--advanced` / `--turbo`: `AdvancedDownloader` (paralelo com byte range, retomável).
+    - `--ftp`: downloader FTP com fallback anônimo.
+    - `--sftp`: downloader SFTP com autenticação SSH multi-método.
+    - `--torrent` ou prefixo `magnet:?` detectado automaticamente: motor de torrent nativo.
+    - Flags `-o <caminho>`, `-q` (silencioso), `--sha256 <hash>` suportados.
+  - `config [show | set <chave> <valor>]`: lê e persiste configurações (`connections`, `speed-limit`, `compression`, `cache`).
+  - Comandos `clear`, `version`, `help` / `?`; `get` e `dl` como apelidos de `download`.
+  - Erros são impressos e o REPL continua — um download com falha nunca encerra a sessão.
+
+### Alterado
+- **Tratamento de erros em locks Mutex no `AdvancedDownloader`:** todas as chamadas `.unwrap()` em `Mutex::lock()` foram substituídas por `.expect("…")` com mensagens descritivas.
+- **Limpeza da API pública do `Optimizer`:** removidos atributos `#[allow(dead_code)]` dos métodos públicos `compress`, `get_cached_file` e `cache_file`.
+
 ## [1.6.1] - 2026-04-27
 
 ### Adicionado

--- a/translations/LIB.es.md
+++ b/translations/LIB.es.md
@@ -10,14 +10,14 @@ proxy y verificación SHA256.
 
 ```toml
 [dependencies]
-Kget = "1.6.1"
+Kget = "1.6.2"
 ```
 
 Features opcionales:
 
 ```toml
-Kget = { version = "1.6.1", features = ["torrent-native"] }
-Kget = { version = "1.6.1", features = ["gui"] }
+Kget = { version = "1.6.2", features = ["torrent-native"] }
+Kget = { version = "1.6.2", features = ["gui"] }
 ```
 
 ## API Principal

--- a/translations/LIB.pt-br.md
+++ b/translations/LIB.pt-br.md
@@ -10,7 +10,7 @@ downloads, proxy e verificação SHA256.
 
 ```toml
 [dependencies]
-Kget = "1.6.1"
+Kget = "1.6.2"
 ```
 
 Features opcionais:

--- a/translations/README.es.md
+++ b/translations/README.es.md
@@ -1,4 +1,4 @@
-# KGet v1.6.1
+# KGet v1.6.2
 
 Un gestor de descargas moderno y rápido escrito en Rust. KGet soporta HTTP/HTTPS, FTP/SFTP y enlaces magnet con cliente torrent nativo.
 
@@ -8,7 +8,8 @@ Un gestor de descargas moderno y rápido escrito en Rust. KGet soporta HTTP/HTTP
 
 - **Multiprotocolo:** HTTP, HTTPS, FTP, SFTP y enlaces magnet.
 - **Cliente torrent nativo:** descargas magnet sin depender de apps externas cuando se compila con `torrent-native`.
-- **Modo turbo:** descargas HTTP/HTTPS paralelas con byte ranges.
+- **Modo turbo:** descargas HTTP/HTTPS paralelas con byte ranges, reanudable.
+- **Modo REPL interactivo:** `kget --interactive` con historial, todos los protocolos y edición de config en vivo.
 - **GUI y CLI:** interfaz gráfica y uso por terminal.
 - **Multiplataforma:** macOS, Linux y Windows.
 - **Verificación SHA256:** valida ISOs y cualquier archivo con hash esperado.
@@ -48,7 +49,7 @@ Descargue versiones para macOS, Linux y Windows desde [Releases](https://github.
 # Descarga simple
 kget https://example.com/archivo.zip
 
-# Modo turbo
+# Modo turbo (paralelo, reanudable)
 kget -a https://example.com/grande.iso
 
 # Guardar en ubicación específica
@@ -57,26 +58,53 @@ kget -O ~/Downloads/archivo.zip https://example.com/archivo.zip
 # Verificar SHA256 esperado
 kget --sha256 <hash> https://example.com/imagen.iso
 
-# Enlace magnet
+# Enlace magnet (detectado automáticamente)
 kget "magnet:?xt=urn:btih:HASH..."
 
-# FTP/SFTP
-kget ftp://usuario:clave@servidor/archivo.zip
-kget sftp://usuario@servidor/archivo.dat
+# FTP anónimo
+kget --ftp ftp://ftp.gnu.org/gnu/emacs/emacs-28.2.tar.gz
+
+# FTP autenticado
+kget --ftp ftp://usuario:clave@servidor/archivo.zip
+
+# SFTP con contraseña en la URL
+kget --sftp sftp://usuario:clave@servidor/ruta/archivo.dat
+
+# SFTP con clave SSH (usa agente SSH o ~/.ssh/id_*)
+kget --sftp sftp://usuario@servidor/ruta/archivo.dat
+```
+
+## Modo Interactivo
+
+```bash
+kget --interactive
+```
+
+Abre un REPL con banner ASCII, historial de comandos y soporte para todos los protocolos:
+
+```
+kget> download -a -o ~/Downloads/ubuntu.iso https://releases.ubuntu.com/...
+kget> download --sftp sftp://user@servidor/backups/db.sql.gz
+kget> download magnet:?xt=urn:btih:...
+kget> config set connections 8
+kget> config set speed-limit 1048576
+kget> help
 ```
 
 ## Opciones principales
 
 | Flag | Descripción |
 |------|-------------|
-| `-a, --advanced` | Modo turbo con conexiones paralelas |
+| `-a, --advanced` | Modo turbo con conexiones paralelas (reanudable) |
 | `-O <path>` | Archivo o carpeta de salida |
 | `-q, --quiet` | Salida mínima |
 | `-p <proxy>` | Proxy HTTP/SOCKS5 |
 | `-l <bytes>` | Límite de velocidad en bytes/s |
 | `--sha256 <hash>` | Verifica el archivo final contra un hash SHA256 esperado |
+| `--ftp` | Usar protocolo FTP |
+| `--sftp` | Usar protocolo SFTP (contraseña o autenticación por clave) |
 | `--gui` | Abre la interfaz gráfica |
-| `--interactive` | Abre el modo REPL interactivo |
+| `-i, --interactive` | Abre el modo REPL interactivo |
 
 ## Biblioteca Rust
 

--- a/translations/README.pt-BR.md
+++ b/translations/README.pt-BR.md
@@ -1,4 +1,4 @@
-# KGet v1.6.1
+# KGet v1.6.2
 
 Um gerenciador de downloads moderno e rápido escrito em Rust. O KGet suporta HTTP/HTTPS, FTP/SFTP e magnet links com cliente torrent nativo.
 
@@ -8,7 +8,8 @@ Um gerenciador de downloads moderno e rápido escrito em Rust. O KGet suporta HT
 
 - **Multi-protocolo:** HTTP, HTTPS, FTP, SFTP e magnet links.
 - **Cliente torrent nativo:** downloads por magnet sem depender de apps externos quando compilado com `torrent-native`.
-- **Modo turbo:** downloads HTTP/HTTPS paralelos com byte ranges.
+- **Modo turbo:** downloads HTTP/HTTPS paralelos com byte ranges, retomável.
+- **Modo interativo REPL:** `kget --interactive` com histórico, todos os protocolos e edição de config ao vivo.
 - **GUI e CLI:** interface gráfica e uso por terminal.
 - **Multiplataforma:** macOS, Linux e Windows.
 - **Verificação SHA256:** valida ISOs e qualquer arquivo com hash esperado.
@@ -48,7 +49,7 @@ Baixe versões para macOS, Linux e Windows em [Releases](https://github.com/davi
 # Download simples
 kget https://example.com/arquivo.zip
 
-# Modo turbo
+# Modo turbo (paralelo, retomável)
 kget -a https://example.com/grande.iso
 
 # Salvar em local específico
@@ -57,26 +58,53 @@ kget -O ~/Downloads/arquivo.zip https://example.com/arquivo.zip
 # Verificar SHA256 esperado
 kget --sha256 <hash> https://example.com/imagem.iso
 
-# Magnet link
+# Magnet link (detectado automaticamente)
 kget "magnet:?xt=urn:btih:HASH..."
 
-# FTP/SFTP
-kget ftp://usuario:senha@servidor/arquivo.zip
-kget sftp://usuario@servidor/arquivo.dat
+# FTP anônimo
+kget --ftp ftp://ftp.gnu.org/gnu/emacs/emacs-28.2.tar.gz
+
+# FTP autenticado
+kget --ftp ftp://usuario:senha@servidor/arquivo.zip
+
+# SFTP com senha na URL
+kget --sftp sftp://usuario:senha@servidor/caminho/arquivo.dat
+
+# SFTP com chave SSH (usa SSH agent ou ~/.ssh/id_*)
+kget --sftp sftp://usuario@servidor/caminho/arquivo.dat
+```
+
+## Modo Interativo
+
+```bash
+kget --interactive
+```
+
+Abre um REPL com banner ASCII, histórico de comandos e suporte a todos os protocolos:
+
+```
+kget> download -a -o ~/Downloads/ubuntu.iso https://releases.ubuntu.com/...
+kget> download --sftp sftp://user@servidor/backups/db.sql.gz
+kget> download magnet:?xt=urn:btih:...
+kget> config set connections 8
+kget> config set speed-limit 1048576
+kget> help
 ```
 
 ## Opções principais
 
 | Flag | Descrição |
 |------|-----------|
-| `-a, --advanced` | Modo turbo com conexões paralelas |
+| `-a, --advanced` | Modo turbo com conexões paralelas (retomável) |
 | `-O <path>` | Arquivo ou pasta de saída |
 | `-q, --quiet` | Saída mínima |
 | `-p <proxy>` | Proxy HTTP/SOCKS5 |
 | `-l <bytes>` | Limite de velocidade em bytes/s |
 | `--sha256 <hash>` | Verifica o arquivo final contra um hash SHA256 esperado |
+| `--ftp` | Usar protocolo FTP |
+| `--sftp` | Usar protocolo SFTP (senha ou autenticação por chave) |
 | `--gui` | Abre a interface gráfica |
-| `--interactive` | Abre o modo REPL interativo |
+| `-i, --interactive` | Abre o modo REPL interativo |
 
 ## Biblioteca Rust
 


### PR DESCRIPTION
- Bump version to 1.6.2 in Cargo.toml and all doc files (README, LIB, translations)
- CHANGELOG: add 1.6.2 entry (EN/PT-BR/ES) documenting SFTP fix, FTP fix, interactive mode, and quality improvements
- README (EN/PT-BR/ES): add Interactive REPL section with usage examples; expand FTP/SFTP examples with anonymous and key-auth variants; add --ftp/--sftp flags to options table
- LIB.md: add FTP and SFTP library usage examples with authentication notes